### PR TITLE
Small changes to make it work on Windows

### DIFF
--- a/pyler/__init__.py
+++ b/pyler/__init__.py
@@ -70,4 +70,5 @@ class EulerProblem(unittest.TestCase):
         except TimeoutError:
             self.fail("Test failed to end in less than a minute.")
         finally:
-            signal.signal(signal.SIGALRM, old_handler)
+            if self.use_signal:
+                signal.signal(signal.SIGALRM, old_handler)

--- a/pyler/website.py
+++ b/pyler/website.py
@@ -1,4 +1,4 @@
-from os import path
+import urllib
 import tempfile
 import itertools
 import pickle
@@ -83,7 +83,7 @@ class Website(object):
         """
         if problem_id:
             url_path = "problem={}".format(problem_id)
-        return path.join(self.base_url, url_path)
+        return urllib.parse.urljoin(self.base_url, url_path)
 
     def get(self, *args, **kwargs):
         """


### PR DESCRIPTION
Two changes:
1/ see #7: os.path doesn't use a valid separator on windows to construct an url. 
Use of urllib instead.

2/ test_time was raising an AttributeError because of signal.SIGALRM, which doesn't exist on windows.
Small tweak to make the test not care if there is no SIGALRM. 